### PR TITLE
add Laravel ServiceProvider file and configuration

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,4 @@
+# for php-coveralls
+service_name: travis-ci
+src_dir: src
+coverage_clover: build/logs/clover.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+composer.lock

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,38 @@
+<?php
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in('src')
+    ->in('tests');
+$config = Symfony\CS\Config\Config::create();
+$config->level(null);
+$config->fixers(
+    array(
+        'braces',
+        'duplicate_semicolon',
+        'elseif',
+        'empty_return',
+        'encoding',
+        'eof_ending',
+        'function_call_space',
+        'function_declaration',
+        'indentation',
+        'join_function',
+        'line_after_namespace',
+        'linefeed',
+        'lowercase_keywords',
+        'parenthesis',
+        'multiple_use',
+        'method_argument_space',
+        'object_operator',
+        'php_closing_tag',
+        'remove_lines_between_uses',
+        'short_array_syntax',
+        'short_tag',
+        'standardize_not_equal',
+        'trailing_spaces',
+        'unused_use',
+        'visibility',
+        'whitespacy_lines',
+    )
+);
+$config->finder($finder);
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+sudo: false
+
+language: php
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.5
+      env:
+        - EXECUTE_CS_CHECK=true
+    - php: 5.6
+      env:
+        - EXECUTE_TEST_COVERALLS=true
+    - php: 7
+    - php: hhvm
+  allow_failures:
+    - php: hhvm
+
+before_install:
+  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  - composer self-update
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls:dev-master ; fi
+
+install:
+  - travis_retry composer install --no-interaction
+  - composer info -i
+
+script:
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer test-coverage ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then composer test ; fi
+  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then composer cs ; fi
+
+after_script:
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer coveralls ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# prooph package CHANGELOG
+
+All notable changes to this project will be documented in this file, in reverse chronological order by release.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@ This is a Laravel package for *prooph components* to get started out of the box 
 and snapshots. It uses Doctrine DBAL with PDO MySQL driver. There are more adapters available.
 
 It provides all [service definitions and a default configuration](config "Laravel Package Resources"). This is more like 
-a Quick-Start package. If you want to use the prooph components in production, we recommended to configure the 
+a Quick-Start package. If you want to use the prooph components in production, we recommend to configure the 
 *prooph components* for your requirements. See the [documentation](http://getprooph.org/ "prooph components documentation") 
 for more details of the *prooph components*.
+
+For rapid prototyping we recommend to use our 
+[prooph-cli](https://github.com/proophsoftware/prooph-cli "prooph command line interface") tool.
 
 ### Available services
 * `Prooph\ServiceBus\CommandBus`: Dispatches commands
@@ -123,9 +126,10 @@ return [
     'event_store' => [
         // list of aggregate repositories
         'user_collection' => [
-            'repository_class' => 'Prooph\ProophessorDo\Infrastructure\Repository\EventStoreUserCollection',
-            'aggregate_type' => 'Prooph\ProophessorDo\Model\User\User',
-            'aggregate_translator' => 'Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator',
+            'repository_class' => \Prooph\ProophessorDo\Infrastructure\Repository\EventStoreUserCollection::class,
+            'aggregate_type' => \Prooph\ProophessorDo\Model\User\User::class,
+            'aggregate_translator' => \Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator::class,
+            'snapshot_store' => \Prooph\EventStore\Snapshot\SnapshotStore::class,
         ],
     ],
     'service_bus' => [
@@ -133,38 +137,36 @@ return [
             'router' => [
                 'routes' => [
                     // list of commands with corresponding command handler
-                    'Prooph\ProophessorDo\Model\User\Command\RegisterUser' => 'Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler'
-                ]
-            ]
+                    \Prooph\ProophessorDo\Model\User\Command\RegisterUser::class => \Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler::class,
+                ],
+            ],
         ],
         'event_bus' => [
             'router' => [
                 'routes' => [
                     // list of events with a list of projectors
-                    'Prooph\ProophessorDo\Model\User\Event\UserWasRegistered' => [
-                        'Prooph\ProophessorDo\Projection\User\UserProjector'
-                    ]
-                ]
-            ]
-        ]
-    ]
+                    \Prooph\ProophessorDo\Model\User\Event\UserWasRegistered::class => [
+                        \Prooph\ProophessorDo\Projection\User\UserProjector::class
+                    ],
+                ],
+            ],
+        ],
+    ],
 ];
 ```
 
 Add the service container factories to `config/dependencies.php`.
 
 ```php
-// add the following config in your config/dependencies.php under the specific config key
+// add the following config in your config/dependencies.php after the other factories
 return [
-    'factories' => [
-        // your factories
-        // Model
-        \Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler::class => \Prooph\ProophessorDo\Container\Model\User\RegisterUserHandlerFactory::class,
-        \Prooph\ProophessorDo\Model\User\UserCollection::class => \Prooph\ProophessorDo\Container\Infrastructure\Repository\EventStoreUserCollectionFactory::class,
-        // Projections
-        \Prooph\ProophessorDo\Projection\User\UserProjector::class => \Prooph\ProophessorDo\Container\Projection\User\UserProjectorFactory::class,
-        \Prooph\ProophessorDo\Projection\User\UserFinder::class => \Prooph\ProophessorDo\Container\Projection\User\UserFinderFactory::class,
-    ]
+    // your factories
+    // Model
+    \Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler::class => \Prooph\ProophessorDo\Container\Model\User\RegisterUserHandlerFactory::class,
+    \Prooph\ProophessorDo\Model\User\UserCollection::class => \Prooph\ProophessorDo\Container\Infrastructure\Repository\EventStoreUserCollectionFactory::class,
+    // Projections
+    \Prooph\ProophessorDo\Projection\User\UserProjector::class => \Prooph\ProophessorDo\Container\Projection\User\UserProjectorFactory::class,
+    \Prooph\ProophessorDo\Projection\User\UserFinder::class => \Prooph\ProophessorDo\Container\Projection\User\UserFinderFactory::class,
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,127 @@
+# Laravel package for prooph components
+
+## Overview
+This is a Laravel package for prooph components to get started out of the box with message bus, CQRS, event sourcing and 
+snapshots. It uses Doctrine DBAL.
+
+It provides all [service definitions and a default configuration](config "Laravel Package Resources"). 
+See the [documentation](http://getprooph.org/) for more details of the prooph components.
+
+### Available services
+* `Prooph\ServiceBus\CommandBus`: Dispatches commands
+* `Prooph\ServiceBus\EventBus`: Dispatches events
+* `Prooph\EventStoreBusBridge\TransactionManager`: Transaction manager for service bus and event store
+* `Prooph\EventStoreBusBridge\EventPublisher`: Publishes events on the event bus
+* `Prooph\EventStore\Adapter\Doctrine\DoctrineEventStoreAdapter`: Doctrine adapter for event store
+* `Prooph\EventStore\Snapshot\SnapshotStore`: Event store snapshot adapter
+* `Prooph\EventStore\Snapshot\Adapter\Doctrine\DoctrineSnapshotAdapter`: Doctrine snapshot adapter
+
+## Installation
+
+You can install prooph/prooph-package via composer by adding `"proophsoftware/prooph-package": "^0.1"` as requirement to 
+your composer.json. Setup your database [migrations](https://github.com/prooph/event-store-doctrine-adapter#database-set-up)
+for the Event Store.
+
+### Service Provider
+In your application configuration add `Monii\Interop\Container\Laravel\ServiceProvider` for container-interop support and
+`Prooph\Package\ProophServiceProvider` to your providers array. Then you have access to the services above.
+
+## Example
+You have only to define your models (Entities, Repositories) and commands/routes. You find all these things in the 
+[prooph components documentation](http://getprooph.org/ "prooph components documentation"). Here is an example config
+from the [proophessor-do example app](https://github.com/prooph/proophessor-do "prooph components in action").
+
+> Run `artisan vendor:publish` to add your configuration for the prooph components
+
+```php
+// in your config/prooph.php
+return [
+    'event_store' => [
+        // list of aggregate repositories
+        'user_collection' => [
+            'repository_class' => 'Prooph\ProophessorDo\Infrastructure\Repository\EventStoreUserCollection',
+            'aggregate_type' => 'Prooph\ProophessorDo\Model\User\User',
+            'aggregate_translator' => 'Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator',
+        ],
+    ],
+    'service_bus' => [
+        'command_bus' => [
+            'router' => [
+                'routes' => [
+                    // list of commands with corresponding command handler
+                    'Prooph\ProophessorDo\Model\User\Command\RegisterUser' => 'Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler'
+                ]
+            ]
+        ],
+        'event_bus' => [
+            'router' => [
+                'routes' => [
+                    // list of events with a list of projectors
+                    'Prooph\ProophessorDo\Model\User\Event\UserWasRegistered' => [
+                        'Prooph\ProophessorDo\Projection\User\UserProjector'
+                    ]
+                ]
+            ]
+        ]
+    ]
+];
+```
+
+Here is an example of the corresponding service XML configuration with container-interop for the proophessor-do example.
+
+```php
+// in your config/dependencies.php
+return [
+    'factories' => [
+        // Model
+        \Prooph\ProophessorDo\Model\User\Handler\RegisterUserHandler::class => \Prooph\ProophessorDo\Container\Model\User\RegisterUserHandlerFactory::class,
+        \Prooph\ProophessorDo\Model\User\UserCollection::class => \Prooph\ProophessorDo\Container\Infrastructure\Repository\EventStoreUserCollectionFactory::class,
+        // Projections
+        \Prooph\ProophessorDo\Projection\User\UserProjector::class => \Prooph\ProophessorDo\Container\Projection\User\UserProjectorFactory::class,
+        \Prooph\ProophessorDo\Projection\User\UserFinder::class => \Prooph\ProophessorDo\Container\Projection\User\UserFinderFactory::class,
+    ]
+];
+```
+
+Here is an example how to call the `RegisterUser` command:
+
+```php
+    /* @var $container \Illuminate\Container\Container */
+    
+    /* @var $commandBus \Prooph\ServiceBus\CommandBus */
+    $commandBus = $container->make(Prooph\ServiceBus\CommandBus::class);
+
+    $command = new \Prooph\ProophessorDo\Model\User\Command\RegisterUser(
+        [
+            'user_id' => \Rhumsaa\Uuid\Uuid::uuid4()->toString(),
+            'name' => 'prooph',
+            'email' => 'my@domain.com',
+        ]
+    );
+
+    $commandBus->dispatch($command);
+```
+
+Here is an example how to get a list of all users from the example above:
+
+```php
+    /* @var $container \Illuminate\Container\Container */
+    $userFinder = $container->make(Prooph\ProophessorDo\Projection\User\UserFinder::class);
+
+    $users = $userFinder->findAll();
+```
+
+## Support
+
+- Ask questions on [prooph-users](https://groups.google.com/forum/?hl=de#!forum/prooph) mailing list.
+- File issues at [https://github.com/proophsoftware/prooph-package/issues](https://github.com/proophsoftware/prooph-package/issues).
+- Say hello in the [prooph gitter](https://gitter.im/prooph/improoph) chat.
+
+## Contribute
+
+Please feel free to fork and extend existing or add new plugins and send a pull request with your changes!
+To establish a consistent code quality, please provide unit tests for all your changes and may adapt the documentation.
+
+## License
+
+Released under the [New BSD License](LICENSE.md).

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+*

--- a/build/logs/.gitignore
+++ b/build/logs/.gitignore
@@ -1,0 +1,2 @@
+!.gitignore
+*

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,69 @@
+{
+  "name": "proophsoftware/prooph-package",
+  "description": "Laravel package for prooph components to get started out of the box with message bus, CQRS, event sourcing and snapshots",
+  "type": "library",
+  "license": "BSD-3-Clause",
+  "homepage": "http://prooph-software.com/",
+  "authors": [
+    {
+      "name": "Alexander Miertsch",
+      "email": "contact@prooph.de",
+      "homepage": "http://prooph-software.com/"
+    },
+    {
+      "name": "Sandro Keil",
+      "email": "contact@prooph.de",
+      "homepage": "http://prooph-software.com/"
+    }
+  ],
+  "keywords": [
+    "prooph",
+    "laravel",
+    "package",
+    "cqrs",
+    "service bus",
+    "event sourcing",
+    "snapshots",
+    "integration"
+  ],
+  "require": {
+    "php": "^5.5 || ^7.0",
+    "illuminate/support": "^5.0",
+    "monii/container-interop-laravel": "^1.0.1",
+    "prooph/event-sourcing": "^4.0",
+    "prooph/event-store": "^6.0",
+    "prooph/event-store-bus-bridge": "^2.0",
+    "prooph/event-store-doctrine-adapter" : "^3.0",
+    "prooph/service-bus": "^5.0.2",
+    "prooph/snapshot-doctrine-adapter": "^1.0",
+    "prooph/snapshotter": "^1.0",
+    "proophsoftware/prooph-cli": "^0.1",
+    "sandrokeil/interop-config": "^0.3.1"
+  },
+  "require-dev": {
+    "illuminate/container": "^5.0",
+    "phpunit/phpunit": "^4.8 || ^5.0",
+    "fabpot/php-cs-fixer": "^1.11"
+  },
+  "autoload": {
+    "psr-4": {
+      "Prooph\\Package\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "ProophTest\\Package\\": "tests/"
+    }
+  },
+  "scripts": {
+    "check": [
+      "@cs",
+      "@test"
+    ],
+    "coveralls": "coveralls",
+    "cs": "php-cs-fixer fix -v --diff --dry-run",
+    "cs-fix": "php-cs-fixer fix -v --diff",
+    "test": "phpunit",
+    "test-coverage": "phpunit --coverage-clover clover.xml"
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,8 @@
   ],
   "require": {
     "php": "^5.5 || ^7.0",
+    "container-interop/container-interop": "^1.1",
+    "doctrine/dbal": "^2.0",
     "illuminate/support": "^5.0",
     "monii/container-interop-laravel": "^1.0.1",
     "prooph/event-sourcing": "^4.0",
@@ -36,14 +38,16 @@
     "prooph/event-store-doctrine-adapter" : "^3.0",
     "prooph/service-bus": "^5.0.2",
     "prooph/snapshot-doctrine-adapter": "^1.0",
-    "prooph/snapshotter": "^1.0",
-    "proophsoftware/prooph-cli": "^0.1",
-    "sandrokeil/interop-config": "^0.3.1"
+    "prooph/snapshotter": "^1.0"
   },
   "require-dev": {
     "illuminate/container": "^5.0",
     "phpunit/phpunit": "^4.8 || ^5.0",
     "fabpot/php-cs-fixer": "^1.11"
+  },
+  "suggest": {
+    "illuminate/database": "If you want to use the database migration schema classes for event store and snapshot",
+    "proophsoftware/prooph-cli": "For Rapid Prototyping, if you want to generate your aggregates, commands, handlers and events."
   },
   "autoload": {
     "psr-4": {

--- a/config/dependencies.php
+++ b/config/dependencies.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/proophsoftware/prooph-package for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/proophsoftware/prooph-package/blob/master/LICENSE.md New BSD License
+ */
+
+return [
+    'invokables' => [
+        \Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy::class => \Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy::class,
+        // Aggregate Translator
+        \Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator::class => \Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator::class,
+    ],
+    'factories' => [
+        \Prooph\EventStore\EventStore::class => \Prooph\EventStore\Container\EventStoreFactory::class,
+        \Prooph\EventStore\Snapshot\SnapshotStore::class => \Prooph\EventStore\Container\Snapshot\SnapshotStoreFactory::class,
+        'Prooph\\EventStore\\Adapter\\Doctrine\\DoctrineEventStoreAdapter' => 'Prooph\\EventStore\\Adapter\\Doctrine\\Container\\DoctrineEventStoreAdapterFactory',
+        'Prooph\\EventStore\\Snapshot\\Adapter\\Doctrine\\DoctrineSnapshotAdapter' => 'Prooph\\EventStore\\Snapshot\\Adapter\\Doctrine\\Container\\DoctrineSnapshotAdapterFactory',
+        // prooph/service-bus set up
+        \Prooph\ServiceBus\CommandBus::class => \Prooph\ServiceBus\Container\CommandBusFactory::class,
+        \Prooph\ServiceBus\EventBus::class   => \Prooph\ServiceBus\Container\EventBusFactory::class,
+        // prooph/event-store-bus-bridge set up
+        \Prooph\EventStoreBusBridge\TransactionManager::class => \Prooph\EventStoreBusBridge\Container\TransactionManagerFactory::class,
+        \Prooph\EventStoreBusBridge\EventPublisher::class     => \Prooph\EventStoreBusBridge\Container\EventPublisherFactory::class,
+    ]
+];

--- a/config/dependencies.php
+++ b/config/dependencies.php
@@ -7,27 +7,25 @@
  * @license   https://github.com/proophsoftware/prooph-package/blob/master/LICENSE.md New BSD License
  */
 
+use \Prooph\Package\Container\InvokableFactory;
+
+// list of services with callable container-interop factories
 return [
-    'invokables' => [
-        \Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy::class => \Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy::class,
-        // Aggregate Translator
-        \Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator::class => \Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator::class,
-    ],
-    'factories' => [
-        // prooph/event-store set up
-        \Prooph\EventStore\EventStore::class => \Prooph\EventStore\Container\EventStoreFactory::class,
-        'Prooph\\EventStore\\Adapter\\Doctrine\\DoctrineEventStoreAdapter' => 'Prooph\\EventStore\\Adapter\\Doctrine\\Container\\DoctrineEventStoreAdapterFactory',
-        // prooph snapshot setup
-        \Prooph\Snapshotter\SnapshotPlugin::class => \Prooph\Snapshotter\Container\SnapshotPluginFactory::class,
-        \Prooph\Snapshotter\Snapshotter::class => \Prooph\Snapshotter\Container\SnapshotterFactory::class,
-        \Prooph\EventStore\Snapshot\SnapshotStore::class => \Prooph\EventStore\Container\Snapshot\SnapshotStoreFactory::class,
-        'Prooph\\EventStore\\Snapshot\\Adapter\\Doctrine\\DoctrineSnapshotAdapter' => 'Prooph\\EventStore\\Snapshot\\Adapter\\Doctrine\\Container\\DoctrineSnapshotAdapterFactory',
-        // prooph/service-bus set up
-        \Prooph\ServiceBus\CommandBus::class => \Prooph\ServiceBus\Container\CommandBusFactory::class,
-        \Prooph\ServiceBus\EventBus::class   => \Prooph\ServiceBus\Container\EventBusFactory::class,
-        // prooph/event-store-bus-bridge set up
-        \Prooph\EventStoreBusBridge\TransactionManager::class => \Prooph\EventStoreBusBridge\Container\TransactionManagerFactory::class,
-        \Prooph\EventStoreBusBridge\EventPublisher::class     => \Prooph\EventStoreBusBridge\Container\EventPublisherFactory::class,
-        // your factories
-    ]
+    // prooph/event-store set up
+    \Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator::class => InvokableFactory::class,
+    \Prooph\EventStore\EventStore::class => \Prooph\EventStore\Container\EventStoreFactory::class,
+    \Prooph\EventStore\Adapter\Doctrine\DoctrineEventStoreAdapter::class => \Prooph\EventStore\Adapter\Doctrine\Container\DoctrineEventStoreAdapterFactory::class,
+    // prooph snapshot setup
+    \Prooph\Snapshotter\SnapshotPlugin::class => \Prooph\Snapshotter\Container\SnapshotPluginFactory::class,
+    \Prooph\Snapshotter\Snapshotter::class => \Prooph\Snapshotter\Container\SnapshotterFactory::class,
+    \Prooph\EventStore\Snapshot\SnapshotStore::class => \Prooph\EventStore\Container\Snapshot\SnapshotStoreFactory::class,
+    \Prooph\EventStore\Snapshot\Adapter\Doctrine\DoctrineSnapshotAdapter::class => \Prooph\EventStore\Snapshot\Adapter\Doctrine\Container\DoctrineSnapshotAdapterFactory::class,
+    // prooph/service-bus set up
+    \Prooph\ServiceBus\CommandBus::class => \Prooph\ServiceBus\Container\CommandBusFactory::class,
+    \Prooph\ServiceBus\EventBus::class => \Prooph\ServiceBus\Container\EventBusFactory::class,
+    \Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy::class => InvokableFactory::class,
+    // prooph/event-store-bus-bridge set up
+    \Prooph\EventStoreBusBridge\TransactionManager::class => \Prooph\EventStoreBusBridge\Container\TransactionManagerFactory::class,
+    \Prooph\EventStoreBusBridge\EventPublisher::class => \Prooph\EventStoreBusBridge\Container\EventPublisherFactory::class,
+    // your factories
 ];

--- a/config/dependencies.php
+++ b/config/dependencies.php
@@ -14,9 +14,13 @@ return [
         \Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator::class => \Prooph\EventSourcing\EventStoreIntegration\AggregateTranslator::class,
     ],
     'factories' => [
+        // prooph/event-store set up
         \Prooph\EventStore\EventStore::class => \Prooph\EventStore\Container\EventStoreFactory::class,
-        \Prooph\EventStore\Snapshot\SnapshotStore::class => \Prooph\EventStore\Container\Snapshot\SnapshotStoreFactory::class,
         'Prooph\\EventStore\\Adapter\\Doctrine\\DoctrineEventStoreAdapter' => 'Prooph\\EventStore\\Adapter\\Doctrine\\Container\\DoctrineEventStoreAdapterFactory',
+        // prooph snapshot setup
+        \Prooph\Snapshotter\SnapshotPlugin::class => \Prooph\Snapshotter\Container\SnapshotPluginFactory::class,
+        \Prooph\Snapshotter\Snapshotter::class => \Prooph\Snapshotter\Container\SnapshotterFactory::class,
+        \Prooph\EventStore\Snapshot\SnapshotStore::class => \Prooph\EventStore\Container\Snapshot\SnapshotStoreFactory::class,
         'Prooph\\EventStore\\Snapshot\\Adapter\\Doctrine\\DoctrineSnapshotAdapter' => 'Prooph\\EventStore\\Snapshot\\Adapter\\Doctrine\\Container\\DoctrineSnapshotAdapterFactory',
         // prooph/service-bus set up
         \Prooph\ServiceBus\CommandBus::class => \Prooph\ServiceBus\Container\CommandBusFactory::class,
@@ -24,5 +28,6 @@ return [
         // prooph/event-store-bus-bridge set up
         \Prooph\EventStoreBusBridge\TransactionManager::class => \Prooph\EventStoreBusBridge\Container\TransactionManagerFactory::class,
         \Prooph\EventStoreBusBridge\EventPublisher::class     => \Prooph\EventStoreBusBridge\Container\EventPublisherFactory::class,
+        // your factories
     ]
 ];

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -10,7 +10,7 @@
 return [
     'connection' => [
         'default' => [
-            'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
+            'driverClass' => \Doctrine\DBAL\Driver\PDOMySql\Driver::class,
             'host' => env('DB_HOST', 'localhost'),
             'port' => '3306',
             'user' => env('DB_USERNAME', 'forge'),

--- a/config/doctrine.php
+++ b/config/doctrine.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/proophsoftware/prooph-package for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/proophsoftware/prooph-package/blob/master/LICENSE.md New BSD License
+ */
+
+return [
+    'connection' => [
+        'default' => [
+            'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
+            'host' => env('DB_HOST', 'localhost'),
+            'port' => '3306',
+            'user' => env('DB_USERNAME', 'forge'),
+            'password' => env('DB_PASSWORD', ''),
+            'dbname' => env('DB_DATABASE', 'forge'),
+            'charset' => 'utf8',
+            'driverOptions' => [
+                1002 => "SET NAMES 'UTF8'"
+            ],
+        ],
+    ],
+ ];

--- a/config/prooph.php
+++ b/config/prooph.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/proophsoftware/prooph-package for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/proophsoftware/prooph-package/blob/master/LICENSE.md New BSD License
+ */
+
+return [
+    'event_store' => [
+        'adapter' => [
+            'type' => 'Prooph\EventStore\Adapter\Doctrine\DoctrineEventStoreAdapter',
+            'options' => [
+                'connection_alias' => 'doctrine.connection.default',
+            ],
+        ],
+        'plugins' => [
+            \Prooph\EventStoreBusBridge\EventPublisher::class,
+            \Prooph\EventStoreBusBridge\TransactionManager::class,
+        ],
+        // list of aggregate repositories
+    ],
+    'service_bus' => [
+        'command_bus' => [
+            'router' => [
+                'routes' => [
+                    // list of commands with corresponding command handler
+                ]
+            ]
+        ],
+        'event_bus' => [
+            'plugins' => [
+                \Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy::class
+            ],
+            'router' => [
+                'routes' => [
+                    // list of events with a list of projectors
+                ]
+            ]
+        ]
+    ]
+];

--- a/config/prooph.php
+++ b/config/prooph.php
@@ -18,6 +18,7 @@ return [
         'plugins' => [
             \Prooph\EventStoreBusBridge\EventPublisher::class,
             \Prooph\EventStoreBusBridge\TransactionManager::class,
+            \Prooph\Snapshotter\SnapshotPlugin::class,
         ],
         // list of aggregate repositories
     ],
@@ -25,9 +26,10 @@ return [
         'command_bus' => [
             'router' => [
                 'routes' => [
+                    \Prooph\Snapshotter\TakeSnapshot::class => \Prooph\Snapshotter\Snapshotter::class,
                     // list of commands with corresponding command handler
-                ]
-            ]
+                ],
+            ],
         ],
         'event_bus' => [
             'plugins' => [
@@ -36,8 +38,25 @@ return [
             'router' => [
                 'routes' => [
                     // list of events with a list of projectors
+                ],
+            ],
+        ],
+    ],
+    'snapshot_store' => [
+        'adapter' => [
+            'type' => \Prooph\EventStore\Snapshot\Adapter\Doctrine\DoctrineSnapshotAdapter::class,
+            'options' => [
+                'connection_alias' => 'doctrine.connection.default',
+                'snapshot_table_map' => [
+                    // list of aggregate root => table (default is snapshot)
                 ]
             ]
         ]
-    ]
+    ],
+    'snapshotter' => [
+        'version_step' => 5, // every 5 events a snapshot
+        'aggregate_repositories' => [
+            // list of aggregate root => aggregate repositories
+        ]
+    ],
 ];

--- a/config/prooph.php
+++ b/config/prooph.php
@@ -6,11 +6,11 @@
  * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
  * @license   https://github.com/proophsoftware/prooph-package/blob/master/LICENSE.md New BSD License
  */
-
+// default example configuration for prooph components, see http://getprooph.org/
 return [
     'event_store' => [
         'adapter' => [
-            'type' => 'Prooph\EventStore\Adapter\Doctrine\DoctrineEventStoreAdapter',
+            'type' => \Prooph\EventStore\Adapter\Doctrine\DoctrineEventStoreAdapter::class,
             'options' => [
                 'connection_alias' => 'doctrine.connection.default',
             ],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuite name="Prooph Package Test Suite">
+        <directory>./tests</directory>
+    </testsuite>
+
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Container/InvokableFactory.php
+++ b/src/Container/InvokableFactory.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/proophsoftware/prooph-package for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/proophsoftware/prooph-package/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Prooph\Package\Container;
+
+use Interop\Container\ContainerInterface;
+
+/**
+ * Factory for instantiating classes with no dependencies
+ */
+final class InvokableFactory
+{
+    public function __invoke(ContainerInterface $container, $requestedName)
+    {
+        return new $requestedName;
+    }
+}

--- a/src/Migration/Schema/EventStoreSchema.php
+++ b/src/Migration/Schema/EventStoreSchema.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/proophsoftware/prooph-package for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/proophsoftware/prooph-package/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Prooph\Package\Migration\Schema;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Use this helper in a Laravel migrations script to set up the event store schema
+ *
+ * Call the appropriated methods in your up() / down() method
+ */
+final class EventStoreSchema
+{
+    /**
+     * Use this method when you work with a single stream strategy
+     *
+     * @param string $streamName Defaults to 'event_stream'
+     * @param bool $withCausationColumns Enable causation columns when using prooph/event-store-bus-bridge
+     */
+    public static function createSingleStream($streamName = 'event_stream', $withCausationColumns = false)
+    {
+        Schema::create($streamName, function (Blueprint $eventStream) use ($streamName, $withCausationColumns) {
+            // UUID4 of the event
+            $eventStream->char('event_id', 36);
+            // Version of the aggregate after event was recorded
+            $eventStream->integer('version', false, true);
+            // Name of the event
+            $eventStream->string('event_name', 100);
+            // Event payload
+            $eventStream->text('payload');
+            // DateTime ISO8601 + microseconds UTC stored as a string e.g. 2016-02-02T11:45:39.000000
+            $eventStream->char('created_at', 26);
+            // UUID4 of linked aggregate
+            $eventStream->char('aggregate_id', 36);
+            // Class of the linked aggregate
+            $eventStream->string('aggregate_type', 100);
+
+            if ($withCausationColumns) {
+                // UUID4 of the command which caused the event
+                $eventStream->char('causation_id', 36);
+                // Name of the command which caused the event
+                $eventStream->string('causation_name', 100);
+            }
+            $eventStream->primary('event_id');
+            // Concurrency check on database level
+            $eventStream->unique(['aggregate_id', 'aggregate_type', 'version'], $streamName . '_m_v_uix');
+        });
+    }
+
+    /**
+     * Use this method when you work with an aggregate type stream strategy
+     *
+     * @param string $streamName [shortclassname]_stream
+     * @param bool $withCausationColumns Enable causation columns when using prooph/event-store-bus-bridge
+     */
+    public static function createAggregateTypeStream($streamName, $withCausationColumns = false)
+    {
+        Schema::create($streamName, function (Blueprint $eventStream) use ($streamName, $withCausationColumns) {
+            // UUID4 of the event
+            $eventStream->char('event_id', 36);
+            // Version of the aggregate after event was recorded
+            $eventStream->integer('version', false, true);
+            // Name of the event
+            $eventStream->string('event_name', 100);
+            // Event payload
+            $eventStream->text('payload');
+            // DateTime ISO8601 + microseconds UTC stored as a string e.g. 2016-02-02T11:45:39.000000
+            $eventStream->char('created_at', 26);
+            // UUID4 of linked aggregate
+            $eventStream->char('aggregate_id', 36);
+            // Class of the linked aggregate
+            $eventStream->string('aggregate_type', 100);
+
+            if ($withCausationColumns) {
+                // UUID4 of the command which caused the event
+                $eventStream->char('causation_id', 36);
+                // Name of the command which caused the event
+                $eventStream->string('causation_name', 100);
+            }
+            $eventStream->primary('event_id');
+            // Concurrency check on database level
+            $eventStream->unique(['aggregate_id', 'version'], $streamName . '_m_v_uix');
+        });
+    }
+
+    /**
+     * Drop a stream schema
+     *
+     * @param string $streamName Defaults to 'event_stream'
+     */
+    public static function dropStream($streamName = 'event_stream')
+    {
+        Schema::drop($streamName);
+    }
+}

--- a/src/Migration/Schema/SnapshotSchema.php
+++ b/src/Migration/Schema/SnapshotSchema.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/proophsoftware/prooph-package for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/proophsoftware/prooph-package/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Prooph\Package\Migration\Schema;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Use this helper in a Laravel migrations script to set up the snapshot store schema
+ *
+ * Call the appropriated methods in your up() / down() method
+ */
+final class SnapshotSchema
+{
+    /**
+     * Creates a snapshot schema
+     *
+     * @param Schema $schema
+     * @param string $snapshotName Defaults to 'snapshot'
+     */
+    public static function create($snapshotName = 'snapshot')
+    {
+        Schema::create($snapshotName, function (Blueprint $snapshot) use ($snapshotName) {
+            // UUID4 of linked aggregate
+            $snapshot->char('aggregate_id', 36);
+            // Class of the linked aggregate
+            $snapshot->string('aggregate_type', 100);
+            // Version of the aggregate after event was recorded
+            $snapshot->integer('last_version', false, true);
+            // DateTime ISO8601 + microseconds UTC stored as a string e.g. 2016-02-02T11:45:39.000000
+            $snapshot->char('created_at', 26);
+            $snapshot->binary('aggregate_root');
+
+            $snapshot->index(['aggregate_id', 'aggregate_type'], $snapshotName . '_m_v_uix');
+        });
+    }
+
+    /**
+     * Drop a snapshot schema
+     *
+     * @param string $snapshotName Defaults to 'snapshot'
+     */
+    public static function drop($snapshotName = 'snapshot')
+    {
+        Schema::drop($snapshotName);
+    }
+}

--- a/src/ProophServiceProvider.php
+++ b/src/ProophServiceProvider.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * prooph (http://getprooph.org/)
+ *
+ * @see       https://github.com/proophsoftware/prooph-package for the canonical source repository
+ * @copyright Copyright (c) 2016 prooph software GmbH (http://prooph-software.com/)
+ * @license   https://github.com/proophsoftware/prooph-package/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Prooph\Package;
+
+use Doctrine\DBAL\DriverManager;
+use Illuminate\Support\ServiceProvider;
+use Interop\Container\ContainerInterface;
+
+class ProophServiceProvider extends ServiceProvider
+{
+    /**
+     * Perform post-registration booting of services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $path = $this->getConfigPath();
+
+        $this->publishes(
+            [
+                $path . '/prooph.php' => config_path('prooph.php'),
+                $path . '/doctrine.php' => config_path('doctrine.php'),
+                $path . '/dependencies.php' => config_path('dependencies.php'),
+            ],
+            'config')
+        ;
+    }
+
+    private function getConfigPath()
+    {
+        return dirname(__DIR__) . '/config';
+    }
+
+    /**
+     * Register any package services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $path = $this->getConfigPath();
+
+        $this->mergeConfigFrom(
+            $path . '/prooph.php', 'prooph'
+        );
+        $this->mergeConfigFrom(
+            $path . '/doctrine.php', 'doctrine'
+        );
+        $this->mergeConfigFrom(
+            $path . '/dependencies.php', 'dependencies'
+        );
+
+        foreach (config('dependencies') as $type => $services) {
+            foreach ($services as $service => $factory) {
+                switch ($type) {
+                    case 'invokables':
+                        $this->app->singleton($service, function () use ($factory) {
+                            return new $factory();
+                        });
+                        break;
+                    case 'factories':
+                        $this->app->singleton($factory, function () use ($factory) {
+                            return new $factory();
+                        });
+                        $this->app->singleton($service, function ($app) use ($factory) {
+                            return $app->make($factory)->__invoke($app->make(ContainerInterface::class));
+                        });
+                        break;
+                    default:
+                        // nothing to do
+                        break;
+                }
+            }
+        }
+
+        $this->app->singleton('doctrine.connection.default', function () {
+            return DriverManager::getConnection(config('doctrine')['connection']['default']);
+        });
+    }
+
+    public function provides()
+    {
+        return [
+            \Prooph\EventStore\EventStore::class,
+            \Prooph\EventStore\Snapshot\SnapshotStore::class,
+            // service bus
+            \Prooph\ServiceBus\CommandBus::class,
+            \Prooph\ServiceBus\EventBus::class,
+            \Prooph\EventStore\Adapter\Doctrine\DoctrineEventStoreAdapter::class,
+            \Prooph\EventStore\Snapshot\Adapter\Doctrine\DoctrineSnapshotAdapter::class,
+            // prooph/event-store-bus-bridge set up
+            \Prooph\EventStoreBusBridge\TransactionManager::class,
+            \Prooph\EventStoreBusBridge\EventPublisher::class,
+            'Prooph\\EventStore\\Adapter\\Doctrine\\DoctrineEventStoreAdapter',
+
+        ];
+    }
+}


### PR DESCRIPTION
There are some problems with merging of configuration, because Laravel doesn't use `array_merge_recursive()` [here](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Support/ServiceProvider.php#L67). For example the event_bus plugins are removed after merge.

A workaround is to have the full configuration in the user config files, but documentation says 

_You may also choose to merge your own package configuration file with the application's copy. This allows your users to include only the options they actually want to override in the published copy of the configuration_.

We provide a default package configuration and the user have to add some configuration to some sub keys. See [README.md](https://github.com/sandrokeil/prooph-package#example) for more details.
