### PR TITLE
Adds Stubs to create migrations automatically with publish command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls:dev-master ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update php-coveralls/php-coveralls ; fi
 
 before_script:
   - mkdir -p "$HOME/.php-cs-fixer"

--- a/README.md
+++ b/README.md
@@ -49,74 +49,8 @@ $ php artisan vendor:publish
 ```
 
 ### Database
-Setup your [database migrations](https://github.com/prooph/event-store-doctrine-adapter#database-set-up)
-for the Event Store and Snapshot with:
-
-```bash
-$ php artisan make:migration create_event_stream_table
-```
-
-Update the class `CreateEventStreamTable`:
-
-```php
-class CreateEventStreamTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
-    public function up()
-    {
-        \Prooph\Package\Migration\Schema\EventStoreSchema::createSingleStream('event_stream', true);
-    }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        \Prooph\Package\Migration\Schema\EventStoreSchema::dropStream('event_stream');
-    }
-}
-```
-
-And now for the snapshot table.
-
-```bash
-$ php artisan make:migration create_snapshot_table
-```
-
-Update the class `CreateSnapshotTable`:
-
-```php
-class CreateSnapshotTable extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
-    public function up()
-    {
-        \Prooph\Package\Migration\Schema\SnapshotSchema::create('snapshot');
-    }
-
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        \Prooph\Package\Migration\Schema\SnapshotSchema::drop('snapshot');
-    }
-}
-```
-
-Now it's time to execute the migrations:
+The Database migrations were published already according to [database migrations](https://github.com/prooph/event-store-doctrine-adapter#database-set-up)
+so now it's time to execute the migrations:
 
 ```bash
 $ php artisan migrate

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "require-dev": {
         "laravel/framework": "^5.0",
         "phpunit/phpunit": "^4.8 || ^5.0",
-        "satooshi/php-coveralls": "^1.0",
+        "php-coveralls/php-coveralls": "^2.1",
         "prooph/php-cs-fixer-config": "^0.1.1",
         "react/promise": "^2.5"
     },

--- a/database/migrations/create_event_stream_table.php.stub
+++ b/database/migrations/create_event_stream_table.php.stub
@@ -1,0 +1,25 @@
+<?php
+
+class CreateEventStreamTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        \Prooph\Package\Migration\Schema\EventStoreSchema::createSingleStream('event_stream', true);
+    }
+
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        \Prooph\Package\Migration\Schema\EventStoreSchema::dropStream('event_stream');
+    }
+}

--- a/database/migrations/create_snapshot_table.php.stub
+++ b/database/migrations/create_snapshot_table.php.stub
@@ -1,0 +1,24 @@
+<?php
+
+class CreateSnapshotTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        \Prooph\Package\Migration\Schema\SnapshotSchema::create('snapshot');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        \Prooph\Package\Migration\Schema\SnapshotSchema::drop('snapshot');
+    }
+}

--- a/src/ProophServiceProvider.php
+++ b/src/ProophServiceProvider.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace Prooph\Package;
 
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
+use Illuminate\Support\ServiceProvider;
 use Prooph\Package\Container\LaravelContainer;
 
 /**
@@ -24,6 +24,7 @@ final class ProophServiceProvider extends ServiceProvider
     /**
      * Perform post-registration booting of services.
      *
+     * @param Filesystem $filesystem
      * @return void
      */
     public function boot(Filesystem $filesystem)
@@ -109,13 +110,14 @@ final class ProophServiceProvider extends ServiceProvider
      * Returns existing migration file if found, else uses the current timestamp.
      *
      * @param Filesystem $filesystem
+     * @param string $filename
      * @return string
      */
     protected function getMigrationFileName(Filesystem $filesystem, string $filename): string
     {
         $timestamp = date('Y_m_d_His');
 
-        return Collection::make($this->app->databasePath().DIRECTORY_SEPARATOR.'migrations'.DIRECTORY_SEPARATOR)
+        return Collection::make($this->app->databasePath().'/migrations/')
             ->flatMap(function ($path) use ($filesystem, $filename) {
                 return $filesystem->glob($path.'*_'.$filename);
             })->push($this->app->databasePath()."/migrations/{$timestamp}_".$filename)


### PR DESCRIPTION
Added Stubs to automatically create migrations for the person implementing the package. This will automatically prepend the datetime as well so that we only need to ask the user to run `artisan:migrate` instead